### PR TITLE
adjust dependencies for new Rust versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["Hyunsik Choi <hyunsik.choi@gmail.com>"]
 [lib]
 name = "jni"
 path = "src/lib.rs"
+
+[dependencies]
+libc = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(libc)]
 extern crate libc;
 
 pub mod native;


### PR DESCRIPTION
build error with Rust 1.7, libc is stable now.
